### PR TITLE
fix: add app version to telemetry

### DIFF
--- a/services/appInsights.ts
+++ b/services/appInsights.ts
@@ -5,6 +5,8 @@ import {
   DecibelDifferenceResult,
   EarVolumeResults,
 } from "../contexts/_internal/types";
+import AppInfo from "../app.json";
+import { Envelope } from "./types";
 
 const RNPlugin = new ReactNativePlugin();
 const appInsights = new ApplicationInsights({
@@ -14,6 +16,13 @@ const appInsights = new ApplicationInsights({
   },
 });
 appInsights.loadAppInsights();
+
+const appVersionEnvelope: Envelope = (item) => {
+  if (item.data) {
+    item.data["app-version"] = AppInfo.expo.version;
+  }
+};
+appInsights.addTelemetryInitializer(appVersionEnvelope);
 
 export const trackResults = (
   earVolumeResults: EarVolumeResults,

--- a/services/types.ts
+++ b/services/types.ts
@@ -1,0 +1,3 @@
+import { ITelemetryItem } from "@microsoft/applicationinsights-web";
+
+export type Envelope = (item: ITelemetryItem) => boolean | void;


### PR DESCRIPTION
Adds `app-version` as a custom property to all events logged to Application Insights.

Closes #88