### PR TITLE
build: use xcode 15.2

### DIFF
--- a/.github/workflows/build-release-ios.yml
+++ b/.github/workflows/build-release-ios.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "15.2"
 
       - name: Set build number to environment variable
         run: echo "BUILD_NUMBER=$(date +'%Y').$(date +'%m%d').${{github.run_number}}" >> $GITHUB_ENV


### PR DESCRIPTION
Xcode 15.4 is not available through GitHub Actions. Switching to using the latest LTS version of Xcode, 15.2.

Closes #99